### PR TITLE
launch yaml is deprecated in xacro files

### DIFF
--- a/iiwa_description/config/iiwa.config.xacro
+++ b/iiwa_description/config/iiwa.config.xacro
@@ -34,7 +34,7 @@
     </gazebo>
 
     <xacro:property name="base_frame_file" value="$(arg base_frame_file)"/>
-    <xacro:property name="base_frame" value="${load_yaml(base_frame_file)['base_frame']}"/>
+    <xacro:property name="base_frame" value="${xacro.load_yaml(base_frame_file)['base_frame']}"/>
     <xacro:iiwa parent="world" prefix="$(arg prefix)">
         <origin xyz="${base_frame['x']} ${base_frame['y']} ${base_frame['z']}"
             rpy="${base_frame['roll']} ${base_frame['pitch']} ${base_frame['yaw']}" />

--- a/iiwa_description/ros2_control/iiwa.r2c_hardware.xacro
+++ b/iiwa_description/ros2_control/iiwa.r2c_hardware.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
     <xacro:macro name="iiwa_r2c_hardware" params="name prefix command_interface robot_ip robot_port initial_positions_file use_sim:=^|false use_fake_hardware:=^|true">
-        <xacro:property name="initial_positions" value="${load_yaml(initial_positions_file)['initial_positions']}"/>
+        <xacro:property name="initial_positions" value="${xacro.load_yaml(initial_positions_file)['initial_positions']}"/>
 
         <ros2_control name="${name}" type="system">
 

--- a/iiwa_description/ros2_control/iiwa.r2c_hw_ds.xacro
+++ b/iiwa_description/ros2_control/iiwa.r2c_hw_ds.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
     <xacro:macro name="iiwa_ros2_control" params="name initial_positions_file">
-        <xacro:property name="initial_positions" value="${load_yaml(initial_positions_file)['initial_positions']}"/>
+        <xacro:property name="initial_positions" value="${xacro.load_yaml(initial_positions_file)['initial_positions']}"/>
 
         <ros2_control name="${name}" type="system">
             <hardware>


### PR DESCRIPTION
The launch file started to fail just a few days a go because load_yaml is deprecated. I substitute this with xacro.load_yaml() in the files where it is used.

[ERROR] [launch]: Caught exception in launch (see debug for traceback): executed command showed stderr output. Command: /opt/ros/humble/bin/xacro /ros2_dev/iiwa_ros2/install/iiwa_description/share/iiwa_description/config/iiwa.config.xacro prefix:="" use_sim:=false use_fake_hardware:=true robot_ip:=192.170.10.2 robot_port:=30200 initial_positions_file:=initial_positions.yaml command_interface:=position base_frame_file:=base_frame.yaml description_package:=iiwa_description runtime_config_package:=iiwa_description controllers_file:=iiwa_controllers.yaml namespace:=/
Captured stderr output:

warning: Using load_yaml() directly is deprecated. Use xacro.load_yaml() instead.
warning: Using load_yaml() directly is deprecated. Use xacro.load_yaml() instead.