### PR TITLE
Point to humble branch of gazebo_ros2_control

### DIFF
--- a/iiwa_ros2.repos
+++ b/iiwa_ros2.repos
@@ -2,4 +2,4 @@ repositories:
     ros-controls/gazebo_ros2_control:
         type: git
         url: https://github.com/ros-controls/gazebo_ros2_control.git
-        version: master
+        version: humble


### PR DESCRIPTION
Use **humble** branch from `gazebo_ros2_control` to build the IIWA stack in standard humble ros distro.

Otherwise there is a build error using the **master** (=rolling) branch:

```terminal
--- stderr: gazebo_ros2_control
/home/tpoignonec/ros_ws/src/ros-controls/gazebo_ros2_control/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp: In member function ‘virtual void gazebo_ros2_control::GazeboRosControlPlugin::Load(gazebo::physics::ModelPtr, sdf::v9::ElementPtr)’:
/home/tpoignonec/ros_ws/src/ros-controls/gazebo_ros2_control/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp:290:67: error: ‘__gnu_cxx::__alloc_traits<std::allocator<hardware_interface::HardwareInfo>, hardware_interface::HardwareInfo>::value_type’ {aka ‘struct hardware_interface::HardwareInfo’} has no member named ‘hardware_plugin_name’
  290 |     std::string robot_hw_sim_type_str_ = control_hardware_info[i].hardware_plugin_name;
      |                                                                   ^~~~~~~~~~~~~~~~~~~~
gmake[2]: *** [CMakeFiles/gazebo_ros2_control.dir/build.make:76: CMakeFiles/gazebo_ros2_control.dir/src/gazebo_ros2_control_plugin.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:139: CMakeFiles/gazebo_ros2_control.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
---
Failed   <<< gazebo_ros2_control [6.74s, exited with code 2]
```